### PR TITLE
fix: docker-push-package doesn't push image into ghcr.io

### DIFF
--- a/.github/workflows/docker-package-push.yml
+++ b/.github/workflows/docker-package-push.yml
@@ -35,4 +35,4 @@ jobs:
           context: .
           push: true
           tags: |
-            networkservicemesh/cmd-nsc:latest
+            ghcr.io/networkservicemesh/cmd-nsc:latest


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>