### PR TITLE
[qfix] Close monitor client after we finished using it

### DIFF
--- a/main.go
+++ b/main.go
@@ -196,6 +196,7 @@ func main() {
 		if err != nil {
 			logger.Fatal(err.Error())
 		}
+		cancelMonitor()
 
 		// Construct a request
 		request := &networkservice.NetworkServiceRequest{


### PR DESCRIPTION
Fixes: https://github.com/networkservicemesh/deployments-k8s/issues/2367