### PR TITLE
[deployments-k8s#2393] Use resetting credentials

### DIFF
--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/nsurl"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/opentracing"
+	_ "github.com/networkservicemesh/sdk/pkg/tools/resetting"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/spiffejwt"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/token"
 	_ "github.com/pkg/errors"

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"
 	"github.com/networkservicemesh/sdk/pkg/tools/nsurl"
 	"github.com/networkservicemesh/sdk/pkg/tools/opentracing"
+	"github.com/networkservicemesh/sdk/pkg/tools/resetting"
 	"github.com/networkservicemesh/sdk/pkg/tools/spiffejwt"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 
@@ -117,10 +118,13 @@ func main() {
 			grpc.PerRPCCredentials(token.NewPerRPCCredentials(spiffejwt.TokenGeneratorFunc(source, c.MaxTokenLifetime))),
 		),
 		grpc.WithTransportCredentials(
-			grpcfd.TransportCredentials(
-				credentials.NewTLS(
-					tlsconfig.MTLSClientConfig(source, source, tlsconfig.AuthorizeAny()),
+			resetting.NewCredentials(
+				grpcfd.TransportCredentials(
+					credentials.NewTLS(
+						tlsconfig.MTLSClientConfig(source, source, tlsconfig.AuthorizeAny()),
+					),
 				),
+				source.Updated(),
 			),
 		),
 	)


### PR DESCRIPTION
## Description
Use `resetting.NewCredentials`.

## Issue link
networkservicemesh/deployments-k8s#2393

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
