### PR TITLE
Delete norecursion from the dnsServerHandler chain

### DIFF
--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -35,7 +35,6 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/tools/dnsutils/fanout"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/dnsutils/next"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/dnsutils/noloop"
-	_ "github.com/networkservicemesh/sdk/pkg/tools/dnsutils/norecursion"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/dnsutils/searches"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/log"

--- a/main.go
+++ b/main.go
@@ -67,7 +67,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils/fanout"
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils/noloop"
-	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils/norecursion"
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils/searches"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -169,7 +168,6 @@ func main() {
 		dnsconfigs.NewDNSHandler(dnsConfigsMap),
 		searches.NewDNSHandler(),
 		noloop.NewDNSHandler(),
-		norecursion.NewDNSHandler(),
 		cache.NewDNSHandler(),
 		fanout.NewDNSHandler(),
 	)


### PR DESCRIPTION
A recursive DNS is used to allow one DNS-server communicates with several other DNS servers to find the desired IP address.

In other words, we won't be able to find an external server without this flag (even do `apk update`)

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>