### PR TITLE
Add interface names into NSM metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -196,7 +196,7 @@ func main() {
 			clientinfo.NewClient(),
 			upstreamrefresh.NewClient(ctx),
 			sriovtoken.NewClient(),
-			mechanisms.NewClient(map[string]networkservice.NetworkServiceClient{
+			mechanisms.NewClientWithMetrics(map[string]networkservice.NetworkServiceClient{
 				vfiomech.MECHANISM:   chain.NewNetworkServiceClient(vfio.NewClient()),
 				kernelmech.MECHANISM: chain.NewNetworkServiceClient(kernel.NewClient()),
 			}),


### PR DESCRIPTION
Task: https://github.com/networkservicemesh/sdk-vpp/issues/768

Add interface details for NSC:
![metrixNew drawio (1)](https://github.com/networkservicemesh/cmd-nsc/assets/10182393/eb496fec-1833-4c26-adf9-33eceaed5b2f)


Depends on: https://github.com/networkservicemesh/sdk/pull/1560