### PR TITLE
[qfix] Use a specific version of alpine for cmd-nsc image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ CMD go test -test.v ./...
 FROM test as debug
 CMD dlv -l :40000 --headless=true --api-version=2 test -test.v ./...
 
-FROM alpine as runtime
+FROM alpine:3.18 as runtime
 COPY --from=build /bin/app /bin/app
 ENTRYPOINT ["/bin/app"]


### PR DESCRIPTION
## Issue
https://github.com/networkservicemesh/integration-k8s-kind/pull/927