### PR TITLE
Check connections received from monitoring

### DIFF
--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -25,7 +25,6 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/null"
-	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/retry"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/upstreamrefresh"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/dnscontext"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/deployments-k8s/issues/9863

After a connection is established by init-container, it remains unattended for some time until cmd-nsc sends a request.
During this short time, any event that disrupts the connection can occur.

In this PR, the connection is checked before Request based on monitoring events and checking the datapath