### PR TITLE
Enable dependabot for updating github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gh-actions-minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "[github-actions] "

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: hmarr/debug-action@v2
 
   check-mergeability:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.actor == 'nsmbot' || (github.actor == 'dependabot[bot]' && startsWith(github.event.workflow_run.head_commit.message, '[github-actions]'))) }}
     uses: networkservicemesh/.github/.github/workflows/check-mergeability.yaml@main
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/update-deployments.yaml
+++ b/.github/workflows/update-deployments.yaml
@@ -6,7 +6,7 @@ on:
       - main
 jobs:
   update-deployments-k8s:
-    if: ${{ github.repository != 'networkservicemesh/cmd-template' }}
+    if: ${{ github.repository != 'networkservicemesh/cmd-template' && !startsWith(github.event.commits[0].message, '[github-actions]') }}
     uses: networkservicemesh/.github/.github/workflows/update-deployments.yaml@main
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR enables Dependabot in the repository to automatically check GitHub Actions versions weekly and create pull requests for any outdated dependencies found.